### PR TITLE
fix(download-campaign): init_firebase() returns None when firebase_admin pre-initialized (2026-08-20 regression)

### DIFF
--- a/hermes/skills/download-campaign/scripts/download_campaign.py
+++ b/hermes/skills/download-campaign/scripts/download_campaign.py
@@ -97,6 +97,18 @@ def slugify(text: str) -> str:
 
 
 def init_firebase():
+    """Initialize Firebase Admin SDK and return a Firestore client.
+
+    Idempotent: safe to call repeatedly. MUST always return a non-None
+    firestore.client() — even when firebase_admin._apps is already populated
+    (which happens after main()'s first init_firebase() call, or if another
+    module like clock_skew_credentials already initialized the SDK). Regression
+    2026-08-20: a deployed refactor moved `return firestore.client()` inside the
+    `if not firebase_admin._apps:` block — when _apps was already truthy, the
+    function fell through with no return value, so every query_candidates()
+    call hit `None.collection(...)` and the wiki-campaign-daily-ingest job
+    failed all 157 real users. See TestInitFirebaseReturnValue for the guard.
+    """
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(CREDENTIALS)
     os.environ["WORLDAI_DEV_MODE"] = "true"
     if not firebase_admin._apps:

--- a/hermes/skills/download-campaign/tests/test_download_campaign.py
+++ b/hermes/skills/download-campaign/tests/test_download_campaign.py
@@ -1,6 +1,7 @@
 """Unit tests for download_campaign.py — focus on pure functions."""
 import sys
 import unittest
+import unittest.mock
 from pathlib import Path
 
 # Add the scripts dir to path so we can import the module
@@ -75,6 +76,67 @@ class TestDependencyCheck(unittest.TestCase):
             f"Missing deps in WA .venv: {missing}. "
             "Run the bootstrap in SKILL.md Phase 1.",
         )
+
+
+class TestInitFirebaseReturnValue(unittest.TestCase):
+    """Regression: init_firebase() must return a non-None firestore client even
+    when firebase_admin was already initialized by another module (e.g.
+    clock_skew_credentials.apply_clock_skew_patch()) or by a prior call to
+    init_firebase() from main(). Bug surfaced 2026-08-20 — every user errored
+    with 'NoneType' object has no attribute 'collection' (157 users failed)."""
+
+    def setUp(self):
+        # Snapshot and reset firebase_admin state so each test starts clean
+        self._orig_apps = dict(dc.firebase_admin._apps)
+        dc.firebase_admin._apps = {}
+        # Stub credentials.Certificate so we never touch a real SA JSON file
+        self._cert_patcher = unittest.mock.patch.object(
+            dc.credentials, "Certificate", return_value=unittest.mock.MagicMock(name="cred")
+        )
+        self._cert_patcher.start()
+
+    def tearDown(self):
+        dc.firebase_admin._apps = self._orig_apps
+        self._cert_patcher.stop()
+
+    def test_init_firebase_returns_client_when_apps_already_initialized(self):
+        """The bug: if firebase_admin._apps is already truthy (e.g. another
+        module or a prior init_firebase() call from main() pre-populated it),
+        init_firebase() used to fall through the entire `if not firebase_admin._apps:`
+        block without ever returning firestore.client(), returning None
+        implicitly — causing 'NoneType' has no attribute 'collection'."""
+        # Simulate firebase_admin already initialized (this is the state after
+        # main()'s first init_firebase() call, which is what 2026-08-20 hit)
+        dc.firebase_admin._apps = {"[DEFAULT]": object()}
+
+        # Stub firestore.client() + initialize_app() so we don't need real
+        # Firebase creds and so we can verify the no-double-init invariant.
+        sentinel = object()
+        with unittest.mock.patch.object(
+            dc.firestore, "client", return_value=sentinel
+        ) as mock_client, unittest.mock.patch.object(
+            dc.firebase_admin, "initialize_app"
+        ) as mock_init:
+            result = dc.init_firebase()
+
+        self.assertIsNotNone(
+            result,
+            "init_firebase() returned None — this is the 2026-08-20 bug",
+        )
+        self.assertIs(result, sentinel)
+        mock_init.assert_not_called()
+        mock_client.assert_called_once()
+
+    def test_init_firebase_returns_client_on_fresh_init(self):
+        """Sanity: when firebase_admin._apps is empty (cold start), the function
+        must still return a client (i.e. the fix didn't regress the happy path)."""
+        dc.firebase_admin._apps = {}
+        sentinel = object()
+        with unittest.mock.patch.object(
+            dc.firestore, "client", return_value=sentinel
+        ), unittest.mock.patch.object(dc.firebase_admin, "initialize_app"):
+            result = dc.init_firebase()
+        self.assertIs(result, sentinel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds the regression test `TestInitFirebaseReturnValue` (2 cases) for the 2026-08-20 launchd regression where `init_firebase()` returned `None` when `firebase_admin._apps` was already populated, causing `'NoneType' object has no attribute 'collection'` to error every one of the 157 real-user campaigns in the `wiki-campaign-daily-ingest` job.
- Documents the always-return contract on `init_firebase()` via docstring (the actual `return firestore.client()` line outside the `if not firebase_admin._apps:` block is already in place on `origin/main`).

## Production code changes

**Before** (deployed file, `~/.hermes/.../download_campaign.py`, mtime 2026-08-19): `init_firebase()` was wrapped in a retry loop where `return firestore.client()` was **inside** the `if not firebase_admin._apps:` block. When `_apps` was already truthy (which happens after `main()`'s first `init_firebase()` call — every subsequent per-user `query_candidates()` hit this path), the function fell through with no return value, returning `None` implicitly. Then `db.collection(...)` raised `AttributeError: 'NoneType' object has no attribute 'collection'`.

**Now** (this PR):
- `origin/main`'s `init_firebase()` already has `return firestore.client()` outside the `if not firebase_admin._apps:` block — the bug pattern does **not** exist on `main`. The only source change in this PR is a docstring that explicitly documents the always-return contract so the bug class can't be silently re-introduced.
- The test `TestInitFirebaseReturnValue` adds a permanent regression guard. Verified-RED: running the same test against the deployed buggy version (`~/.hermes/.../download_campaign.py`) produced `AssertionError: unexpectedly None : init_firebase() returned None — this is the 2026-08-20 bug`, proving the test exercises the bug class.

## Test changes

- New test class `TestInitFirebaseReturnValue` in `hermes/skills/download-campaign/tests/test_download_campaign.py` with 2 cases:
  - `test_init_firebase_returns_client_when_apps_already_initialized` — the regression test: stubs `firebase_admin._apps = {"[DEFAULT]": object()}`, calls `init_firebase()`, asserts the return is a non-None firestore client sentinel and `initialize_app` is **not** called again.
  - `test_init_firebase_returns_client_on_fresh_init` — cold-start sanity: stubs empty `_apps`, asserts `init_firebase()` still returns the client (i.e. the fix doesn't regress the happy path).
- Full suite (`python3 -m unittest discover -s hermes/skills/download-campaign/tests -v`) ran 15 tests, 9 passed, 6 skipped (pre-existing RESOLVER.md skips), 0 failures.

## Post-merge action for the operator (not in this PR)

After merge, the operator should re-export the skill from `claude-commands` to `~/.hermes/skills/download-campaign/scripts/download_campaign.py` to overwrite the deployed buggy version with the correct `origin/main` version. Then manually invoke `bash ~/.hermes/scripts/wiki-campaign-daily-ingest.sh` to confirm a successful run with per-user "Found N candidates" lines.

## Known limitations

- The deployed file (`~/.hermes/.../download_campaign.py`) currently has additional improvements over `origin/main` — most notably the chained-cause logging in `_process_candidates` (`e.__cause__ or e.__context__` formatting) and the `$USER` → `jleechan` substitution. Those improvements will be **lost** when the operator re-exports, because `origin/main`'s older clean version does not contain them. A follow-up PR should port those improvements into `origin/main` to avoid regressing Slack error readability.
- This PR does not address the underlying "why does main() call init_firebase() once and then query_candidates() also calls it?" duplication — that's a refactor, not a fix. The docstring + test guard is sufficient for the 2026-08-20 regression.

## Files

- `hermes/skills/download-campaign/scripts/download_campaign.py` — +12 lines (docstring on `init_firebase`)
- `hermes/skills/download-campaign/tests/test_download_campaign.py` — +62 lines (TestInitFirebaseReturnValue class with 2 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production control-flow change; only a docstring and unit tests around an existing return. Low blast radius if tests are wrong.
> 
> **Overview**
> Locks in the contract that `init_firebase()` always returns a Firestore client, even when `firebase_admin._apps` is already populated (after `main()`’s first init or another module). That path is what `query_candidates()` hits on every user in the daily ingest job.
> 
> Production code is unchanged except a docstring on that always-return requirement. Adds `TestInitFirebaseReturnValue` covering pre-initialized SDK (no second `initialize_app`) and cold start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca422fd451cfa4066e7df32ed0b3da9bbf6bdad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->