### PR TITLE
chore: gitignore .claude/worktrees/ runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,10 @@ results/
 # Claude Code runtime files
 .claude/scheduled_tasks.lock
 
+# Agent runtime worktrees (created by Agent Orchestrator under .claude/worktrees/agent-*
+# — runtime state, not source. 4 stale entries seen 2026-08-26 on this branch, see bead bd-m7n.)
+.claude/worktrees/
+
 # home-config snapshots must NEVER be committed here (2026-07-12 public leak incident)
 backup/
 


### PR DESCRIPTION
## Summary
- Ignore `.claude/worktrees/` — runtime state created by Agent Orchestrator under `.claude/worktrees/agent-<uuid>/` for scratch agent worktrees, never source.
- 4 stale entries observed on `fix/web-advice-browser-only-20260825` branch: `agent-a1f01f6b9f3f79f95`, `agent-a3bbc188ed6f0c55e`, `agent-aaa155b0ea7219e5d`, `agent-ab205520941a0942f`.
- This PR adds the gitignore entry; cleanup of the existing entries on disk (if any are tracked in other branches) is not in scope and would be a destructive bulk action.

## Test plan
- [x] `git status --short` on a clean working tree shows no `.claude/worktrees/` entries.
- [x] `git check-ignore -v .claude/worktrees/test/` reports the rule.
- [x] No files tracked under that path are affected by this PR.

## Verification (local)
```
$ git diff origin/main..HEAD -- .gitignore
+# Agent runtime worktrees (created by Agent Orchestrator under .claude/worktrees/agent-*
+# — runtime state, not source. 4 stale entries seen 2026-08-26 on this branch, see bead bd-m7n.)
+.claude/worktrees/
```

## Related
- bead bd-m7n (P3) — separate discussion about `.claude/skills/command-research/SKILL.md`, intentionally NOT addressed in this PR (it touches a tracked slash command path and needs a separate decision: restore / rewrite / retire).

CLI: claude-code
Model: minimax-m3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `.gitignore`; no application, auth, or tracked-path changes.
> 
> **Overview**
> Adds **`.claude/worktrees/`** to `.gitignore` so Agent Orchestrator scratch worktrees under `agent-*` are treated as local runtime state, not repo source—alongside existing ignores like `.agentloop/` and `backup/`.
> 
> The change includes a short comment documenting the orchestrator path and referencing bead **bd-m7n** (stale worktrees observed on a branch). It does **not** remove any already-tracked files or clean up on-disk entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b34929e4729e51d71cdbeec4fc153219cb5d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->